### PR TITLE
Fix temper bypass and faust dsp

### DIFF
--- a/bank/plugins/temper/temper.dsp
+++ b/bank/plugins/temper/temper.dsp
@@ -79,7 +79,7 @@ with {
 
 // We have a resonant lowpass filter at the beginning of our signal chain
 // to control what part of the input signal becomes the modulating signal.
-filter = resonlp(pfilterfc, pfilterq, 1.0);
+filter = fi.resonlp(pfilterfc, pfilterq, 1.0);
 
 // Our main processing block.
 main = (+ : modfilter : fi.dcblocker) ~ *(pfeedback) : gain with {
@@ -92,6 +92,6 @@ main = (+ : modfilter : fi.dcblocker) ~ *(pfeedback) : gain with {
 
 // And the overall process declaration.
 
-output = _,_ : + : ba.bypass1(bypass, filter,main) <: _,_;
+output = _,_ : + : ba.bypass1(bypass, filter:main) <: _,_;
 
 process = output;


### PR DESCRIPTION
This fixes the bypass button on the Temper WAM plugin. 

I found that the `temper.dsp` patch had some syntax issues namely `ba.bypass1`. I've proposed these changes, but would love to know how to recompile the .dsp file to generate the `temper.wasm` file. 

From faustide.grame.fr, I tried this

![image](https://github.com/user-attachments/assets/dca747b6-08c1-4645-a1f6-da351b6af911)

Bypass seems to work but other knobs are broken. 